### PR TITLE
Corrected where the root leads to

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -28,13 +28,13 @@ function registerRoutes(app) {
 
         if (tempCookie === 'loggedIn') {
             // If the user is logged in, send them to the user portal.
-            console.log('GET /portal sending ./res/user_portal.html');
-            res.sendFile('./view/user_portal.html', { root: __dirname });
+            console.log('GET /FTU-Main sending ./res/FTU-Main.html');
+            res.sendFile('./view/FTU-Main.html', { root: __dirname });
             
         } else if (tempCookie === 'loggedAgain') {
-            // If the user has logged in before (TEMP LOGIC), send them to ProjectView
-            console.log('GET /ProjectView sending ./res/ProjectView.html');
-            res.sendFile('./view/ProjectView.html', { root: __dirname });
+            // If the user has logged in before (TEMP LOGIC), send them to ProjectView;
+            console.log('GET /portal sending ./res/user_portal.html');
+            res.sendFile('./view/user_portal.html', { root: __dirname });
 
         } else {
             // Otherwise, send them to the features page


### PR DESCRIPTION
Previous submission had the root directory leading to the wrong pages when cookie logic was used.

Not logged in leads to features, logged in leads to First Time User, then logged in twice leads to the portal.

Awaiting merge into development.