### PR TITLE
Scrum 53/55- Implemented Hyperlink and Scroll Menu Widgets

### DIFF
--- a/blueprint/src/app/canvas/Canvas.jsx
+++ b/blueprint/src/app/canvas/Canvas.jsx
@@ -5,7 +5,7 @@ import { WidgetRenderer } from "./WidgetRenderer";
 import styles from "./page.module.css";
 import React from "react";
 
-export function Canvas({ widgets, isPlacing, isDragging, widgetToPlace, selectedWidgets, setSelectedWidgets,
+export function Canvas({ widgets, changeWidgetProperty, isPlacing, isDragging, widgetToPlace, selectedWidgets, setSelectedWidgets,
     setIsDragging, updateWidget, scale, setScale, setTransformCoords, currentPage, canvasRef, handleCanvasClick }) {
 
     return (
@@ -57,6 +57,7 @@ export function Canvas({ widgets, isPlacing, isDragging, widgetToPlace, selected
                                 onDragStart={() => setIsDragging(true)}
                                 onDragStop={() => setIsDragging(false)}
                                 alertDragStop={updateWidget}
+                                changeWidgetProperty={changeWidgetProperty}
                                 scale={scale}
                             />
                             ))}

--- a/blueprint/src/app/canvas/LeftPanel.jsx
+++ b/blueprint/src/app/canvas/LeftPanel.jsx
@@ -16,6 +16,8 @@ export function LeftPanel({ createWidget }) {
           <button className={styles.categoryItem} onClick={() => createWidget('video')}>Video</button>
           <button className={styles.categoryItem} onClick={() => createWidget('dropdown')}>Dropdown</button>
           <button className={styles.categoryItem} onClick={() => createWidget('advert')}>Advertisement</button>
+          <button className={styles.categoryItem} onClick={() => createWidget('hyperlink')}>Hyperlink</button>
+          <button className={styles.categoryItem} onClick={() => createWidget('menuScroll')}>Menu Scroll</button>
 
           <div className={styles.divider}></div>
 

--- a/blueprint/src/app/canvas/RightPanel.jsx
+++ b/blueprint/src/app/canvas/RightPanel.jsx
@@ -5,7 +5,7 @@ import { RenderPage } from "./HtmlConverter";
 export function RightPanel({
     changeWidgetProperty, selectedWidgets, widgets, deleteWidget,
     pages, selectedPageID, setSelectedPageID, currentPage, createPage, changePageProperty
-   }) {
+    }) {
     const [buttonSelected, setButtonSelected] = useState(false);
 
     const handleButtonClick = () => {
@@ -76,6 +76,96 @@ export function RightPanel({
                   changeWidgetProperty(widget.id, { rotation: parseInt(e.target.value || "0", 10) })
                 }
               />
+
+              {/* ===== Menu Scroll controls ===== */}
+              {widget.type === 'menuScroll' && (() => {
+                const draft = widget.itemsText ?? (widget.items || []).join(", ");
+                const commitItems = (raw) => {
+                  const arr = (raw || "").split(",").map(s => s.trim()).filter(Boolean);
+                  const normalizedText = arr.join(", ");
+                  changeWidgetProperty(widget.id, { items: arr, itemsText: normalizedText });
+                };
+
+                return (
+                  <>
+                    <p>Menu Items (comma-separated):</p>
+                    <textarea
+                      value={draft}
+                      onChange={e => changeWidgetProperty(widget.id, { itemsText: e.target.value })}
+                      onBlur={e => commitItems(e.currentTarget.value)}
+                      style={{ width: '100%', minHeight: '80px' }}
+                    />
+
+                    <p>Font Size:</p>
+                    <input
+                      type="number"
+                      min="8"
+                      value={widget.fontSize || 14}
+                      onChange={e => changeWidgetProperty(widget.id, { fontSize: parseInt(e.target.value, 10) })}
+                    />
+
+                    <p>Text Color:</p>
+                    <input
+                      type="color"
+                      value={widget.textColor || "#333333"}
+                      onChange={e => changeWidgetProperty(widget.id, { textColor: e.target.value })}
+                    />
+
+                    <p>Item Padding:</p>
+                    <input
+                      type="number"
+                      min="0"
+                      value={widget.itemPadding || 8}
+                      onChange={e => changeWidgetProperty(widget.id, { itemPadding: parseInt(e.target.value, 10) })}
+                    />
+                  </>
+                );
+              })()}
+
+              {/* ===== Hyperlink controls ===== */}
+              {widget.type === 'hyperlink' && (
+            <>
+              <p>Display Text:</p>
+              <input
+                type="text"
+                value={widget.text || ""}
+                onChange={e => changeWidgetProperty(widget.id, { text: e.target.value })}
+              />
+
+              <p>URL:</p>
+              <input
+                type="text"
+                placeholder="https://example.com"
+                value={widget.url || ""}
+                onChange={e => changeWidgetProperty(widget.id, { url: e.target.value })}
+              />
+
+              <p>Font Size:</p>
+              <input
+                type="number"
+                min="1"
+                max="70"
+                value={widget.fontSize || 12}
+                onChange={e => changeWidgetProperty(widget.id, { fontSize: parseInt(e.target.value, 10) })}
+              />
+
+              <p>Text Color:</p>
+              <input
+                type="color"
+                value={widget.textColor || "#0000ee"}
+                onChange={e => changeWidgetProperty(widget.id, { textColor: e.target.value })}
+              />
+
+              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span>Open in new tab</span>
+                <input
+                  type="checkbox"
+                  checked={!!widget.openInNewTab}
+                  onChange={e => changeWidgetProperty(widget.id, { openInNewTab: e.target.checked })}
+                />
+              </label>
+            </>
+          )}
   
               {/* ===== Video controls ===== */}
               {widget.type === 'video' && (

--- a/blueprint/src/app/canvas/WidgetRenderer.js
+++ b/blueprint/src/app/canvas/WidgetRenderer.js
@@ -2,6 +2,8 @@ import { Box } from '../components/widgets/Box';
 import { Video } from "../components/widgets/video";
 import { Dropdown } from "../components/widgets/Dropdown";
 import { Advert } from "../components/widgets/Advert";
+import { Hyperlink } from '../components/widgets/Hyperlink';
+import { MenuScroll } from "../components/widgets/MenuScroll";
 
 export function WidgetRenderer({ widget, onClick, alertDragStop, isSelected, onDragStart, onDragStop, scale, changeWidgetProperty }) {
 
@@ -32,6 +34,13 @@ export function WidgetRenderer({ widget, onClick, alertDragStop, isSelected, onD
             />;
     case "advert":
       return <Advert {...common} />;
+    
+    case "hyperlink":
+      return <Hyperlink {...common} />;
+
+    case "menuScroll":
+      return <MenuScroll {...common} changeWidgetProperty={changeWidgetProperty} />;
+  
     default:
       console.warn("Warning: Unknown widget type:", widget.type);
       return null;

--- a/blueprint/src/app/canvas/page.js
+++ b/blueprint/src/app/canvas/page.js
@@ -290,6 +290,50 @@ export default function CanvasPage() {
         };
         break;
 
+      case 'hyperlink':
+        newWidget = {
+          type: 'hyperlink',
+          id: nextId,
+          x: canvasMousePos.x,
+          y: canvasMousePos.y,
+          width: 150,
+          height: 40,
+          isSelected: false,
+          isMoving: true,
+          backgroundColor: 'transparent', // Links don't need a background
+          pointerEventsNone: true,
+          rotation: 0,
+          // custom props:
+          text: 'Click Here',
+          url: 'http://localhost:3000/features',
+          fontSize: 12,
+          textColor: '#0000ee',
+          openInNewTab: true,
+        };
+        break;
+
+      case 'menuScroll':
+        newWidget = {
+          type: 'menuScroll',
+          id: nextId,
+          x: canvasMousePos.x,
+          y: canvasMousePos.y,
+          width: 200,
+          height: 250,
+          isSelected: false,
+          isMoving: true,
+          backgroundColor: '#f0f0f0',
+          pointerEventsNone: true,
+          rotation: 0,
+          // custom props:
+          items: ['Menu Item 1', 'Menu Item 2', 'Menu Item 3', 'Menu Item 4', 'Menu Item 5'],
+          fontSize: 14,
+          textColor: '#333333',
+          itemPadding: 8,
+          selectedValue: 'Menu Item 1', // Default to the first item
+        };
+        break;
+
       default:
         console.warn('Warning: Unknown widget type: ' + typeToMake);
         return;
@@ -358,6 +402,7 @@ export default function CanvasPage() {
         currentPage={currentPage}
         canvasRef={canvasRef}
         handleCanvasClick={handleCanvasClick}
+        changeWidgetProperty={changeWidgetProperty}
       />
 
       {/* Panel on the right, showing options for the selected widgets and the canvas page */}

--- a/blueprint/src/app/components/widgets/Hyperlink.js
+++ b/blueprint/src/app/components/widgets/Hyperlink.js
@@ -1,0 +1,46 @@
+import { Widget } from './Widget';
+
+export function Hyperlink(props) {
+    const {
+        text = 'Default Link',
+        url = '#',
+        fontSize = 12,
+        textColor = '#0000ee',
+        openInNewTab = true,
+    } = props;
+
+    // These styles will be applied to the main div inside the Widget component.
+    // This makes the entire widget a flex container to center its contents.
+    const containerStyle = {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+    };
+
+    return (
+        // We pass our containerStyle to the parent Widget
+        <Widget {...props} style={containerStyle}>
+        {/* This <a> tag is now a child of a flex container.
+            It no longer needs width/height of 100% and will shrink to fit the text,
+            leaving empty, clickable space around it inside the widget bounds.
+        */}
+        <a
+            href={url}
+            target={openInNewTab ? '_blank' : '_self'}
+            rel="noopener noreferrer"
+            style={{
+            fontSize: `${fontSize}px`,
+            color: textColor,
+            textDecoration: 'underline',
+            fontFamily: 'sans-serif',
+            }}
+            // This stops the click from deselecting the widget by bubbling up to the canvas
+            onClick={(e) => e.stopPropagation()}
+        >
+            {text}
+        </a>
+        </Widget>
+    );
+}

--- a/blueprint/src/app/components/widgets/MenuScroll.js
+++ b/blueprint/src/app/components/widgets/MenuScroll.js
@@ -1,0 +1,78 @@
+import { Widget } from './Widget';
+
+export function MenuScroll(props) {
+    const {
+        items = [],
+        fontSize = 14,
+        textColor = '#333333',
+        itemPadding = 8,
+        backgroundColor,
+        selectedValue,
+        changeWidgetProperty,
+        id,
+    } = props;
+
+    const scrollContainerClass = `menu-scroll-container-${id}`;
+
+    const handleItemClick = (e, item) => {
+        e.stopPropagation();
+        changeWidgetProperty(id, { selectedValue: item });
+    };
+
+    return (
+        <Widget {...props} style={{ backgroundColor: backgroundColor || '#f0f0f0' }}>
+        {/* These are the styles that were accidentally removed. They are now restored. */}
+        <style>{`
+            .${scrollContainerClass}::-webkit-scrollbar {
+            width: 12px;
+            }
+            .${scrollContainerClass}::-webkit-scrollbar-track {
+            background: #e0e0e0;
+            border-radius: 10px;
+            }
+            .${scrollContainerClass}::-webkit-scrollbar-thumb {
+            background: #888;
+            border-radius: 10px;
+            border: 3px solid #e0e0e0;
+            }
+            .${scrollContainerClass}::-webkit-scrollbar-thumb:hover {
+            background: #555;
+            }
+        `}</style>
+        
+        <div
+            className={scrollContainerClass}
+            style={{
+            width: '100%',
+            height: '100%',
+            overflowY: 'scroll',
+            fontFamily: 'sans-serif',
+            fontSize: `${fontSize}px`,
+            }}
+            onWheel={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+        >
+            {items.map((item, index) => {
+            const isSelected = selectedValue === item;
+
+            return (
+                <div
+                key={index}
+                style={{
+                    padding: `${itemPadding}px`,
+                    borderBottom: '1px solid #ddd',
+                    cursor: 'pointer',
+                    backgroundColor: isSelected ? '#a0c4ff' : 'transparent',
+                    color: isSelected ? '#001d3d' : textColor,
+                    fontWeight: isSelected ? 'bold' : 'normal',
+                }}
+                onClick={(e) => handleItemClick(e, item)}
+                >
+                {item}
+                </div>
+            );
+            })}
+        </div>
+        </Widget>
+    );
+}


### PR DESCRIPTION
- All widgets in this commit are able to be drag and dropped onto the canvas page, can be rotated, can be resized, and can be deleted. 
- The hyperlink widget can change the font size and color, change the text that is displayed, change where the link takes the user, and can be set to open a new tab or redirect the current tab.
- The Scroll Menu widget is able to select a widget, highlight the selected widget, and scroll once the options do not fit the widgets preferred size. Extra editing options for this widget include the ability to add/remove options, change font size, change background and text color, and increase/decrease padding between menu options.
- Testing has been conducted to test combinations of all the features listed above. 